### PR TITLE
Fix instructions in description_hint

### DIFF
--- a/diversify.py
+++ b/diversify.py
@@ -38,7 +38,7 @@ description_hint = """
 
         http://localhost/?code={code-pattern}
 
-        where you should copy the code-pattern and paste into your terminal. 
+        where you should copy the whole URL and paste into your terminal. 
         These steps are only necessary once and are a current limitation of the
         spotify WEB API.
 


### PR DESCRIPTION
This was most likely the source of my confusion in #11; this will instruct the user to copy the whole URL now.